### PR TITLE
Add global default StatTrak setting

### DIFF
--- a/AstraSkinsPlugin.cs
+++ b/AstraSkinsPlugin.cs
@@ -113,17 +113,19 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         _config = config;
         _storage = storage;
         _skinManager = new SkinManager(storage, catalog, Logger,
-            (delay, action) => AddTimer(delay, () => action(), TimerFlags.STOP_ON_MAPCHANGE));
+            (delay, action) => AddTimer(delay, () => action(), TimerFlags.STOP_ON_MAPCHANGE),
+            config.EnableAllWeaponsStatTrak);
         _menuManager = new MenuManager(_skinManager, config, Localizer, Logger);
         _ready = true;
 
         Logger.LogInformation(
-            "Astra Skins loaded: {Weapons} weapons, {KnifeSkins} knife skins, {GloveSkins} glove skins, {Agents} agents, DB={DatabaseMode}",
+            "Astra Skins loaded: {Weapons} weapons, {KnifeSkins} knife skins, {GloveSkins} glove skins, {Agents} agents, DB={DatabaseMode}, AllWeaponsStatTrak={AllWeaponsStatTrak}",
             catalog.Weapons.Count,
             catalog.KnifeSkinsById.Count,
             catalog.GloveSkinsById.Count,
             catalog.Agents.Count,
-            config.DatabaseMode);
+            config.DatabaseMode,
+            config.EnableAllWeaponsStatTrak);
     }
 
     private ISkinStorage CreateStorage(PluginConfig config)

--- a/Models/PluginConfig.cs
+++ b/Models/PluginConfig.cs
@@ -12,6 +12,7 @@ public sealed class PluginConfig : BasePluginConfig
     public MySqlConfig MySql { get; set; } = new();
     public MenuConfig Menu { get; set; } = new();
     public CustomizationConfig Customization { get; set; } = new();
+    public bool EnableAllWeaponsStatTrak { get; set; } = true;
     public DefinitionPathConfig Definitions { get; set; } = new();
     public bool EnableAdminReloadCommand { get; set; } = true;
     public string AdminReloadPermission { get; set; } = "@css/config";

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 
 Overrides apply on top of the selected skin, take effect instantly, and persist in the database. They target the weapon currently held (knife included); pass `gloves` as the first argument to target equipped gloves instead. A skin must be selected for the item first.
 
-StatTrak works the same way: enable it on a weapon or knife and the counter goes up with every kill you get with that item, persisting across reconnects and map changes.
+StatTrak works the same way: enable it on a weapon or knife and the counter goes up with every kill you get with that item, persisting across reconnects and map changes. With `EnableAllWeaponsStatTrak` enabled (the default), every selected weapon or knife skin starts with StatTrak at `0`; set it to `false` to require `!stattrak` for each item.
 
 > **Tip:** seeds only change finishes whose pattern placement varies — Case Hardened, Crimson Web, Marble Fade, Fade. Most other skins look identical on every seed.
 
@@ -159,6 +159,7 @@ Results respect permissions and are capped at 64 entries; already-equipped items
     "Permission": "",
     "MaxNameTagLength": 20
   },
+  "EnableAllWeaponsStatTrak": true,
   "Definitions": {
     "Weapons": "data/weapons.json",
     "Knives": "data/knives.json",
@@ -184,6 +185,7 @@ Results respect permissions and are capped at 64 entries; already-equipped items
 | `Customization.Enabled` | Master switch for `!seed` / `!wear` / `!nametag` |
 | `Customization.Permission` | Restrict customization to a flag; empty = everyone |
 | `Customization.MaxNameTagLength` | Name tag cap, 4–32 (default 20 matches the real game) |
+| `EnableAllWeaponsStatTrak` | Apply StatTrak at count 0 to every selected weapon/knife by default; set `false` to require `!stattrak` |
 
 ### SQLite
 

--- a/SkinManager.cs
+++ b/SkinManager.cs
@@ -20,6 +20,7 @@ public sealed class SkinManager : IDisposable
     private readonly ISkinStorage _storage;
     private readonly ILogger _logger;
     private readonly EconAttributeApplicator _econAttributes;
+    private readonly bool _enableAllWeaponsStatTrak;
     private readonly Dictionary<ulong, PlayerSkinProfile> _profiles = new();
     private readonly HashSet<ulong> _loadingProfiles = new();
     private readonly HashSet<ulong> _activeSteamIds = new();
@@ -90,11 +91,17 @@ public sealed class SkinManager : IDisposable
 
     public DefinitionCatalog Catalog { get; private set; }
 
-    public SkinManager(ISkinStorage storage, DefinitionCatalog catalog, ILogger logger, Action<float, Action>? scheduleDelayed = null)
+    public SkinManager(
+        ISkinStorage storage,
+        DefinitionCatalog catalog,
+        ILogger logger,
+        Action<float, Action>? scheduleDelayed = null,
+        bool enableAllWeaponsStatTrak = true)
     {
         _storage = storage;
         Catalog = catalog;
         _logger = logger;
+        _enableAllWeaponsStatTrak = enableAllWeaponsStatTrak;
         _scheduleDelayed = scheduleDelayed;
         _econAttributes = new EconAttributeApplicator(logger);
     }
@@ -584,7 +591,35 @@ public sealed class SkinManager : IDisposable
         }
 
         var target = IsKnife(weaponName) ? KnifeTarget : weaponName;
-        if (!profile.Customizations.TryGetValue(target, out var customization) || customization.StatTrak is null)
+        var hasSelectedItem = IsKnife(weaponName)
+            ? profile.KnifeSkinId is not null || profile.KnifeId is not null
+            : profile.WeaponSkins.ContainsKey(weaponName);
+        if (!hasSelectedItem && !profile.Customizations.ContainsKey(target))
+        {
+            return;
+        }
+
+        if (!profile.Customizations.TryGetValue(target, out var customization))
+        {
+            if (!_enableAllWeaponsStatTrak)
+            {
+                return;
+            }
+
+            customization = new WeaponCustomization { StatTrak = 0 };
+            profile.Customizations[target] = customization;
+        }
+        else if (customization.StatTrak is null)
+        {
+            if (!_enableAllWeaponsStatTrak)
+            {
+                return;
+            }
+
+            customization.StatTrak = 0;
+        }
+
+        if (customization.StatTrak is null)
         {
             return;
         }
@@ -1373,7 +1408,7 @@ public sealed class SkinManager : IDisposable
             var seed = customization?.Seed ?? cosmetic.Seed;
             var wear = customization?.Wear ?? cosmetic.Wear;
 
-            var statTrak = customization?.StatTrak;
+            var statTrak = customization?.StatTrak ?? (_enableAllWeaponsStatTrak ? 0 : null);
 
             weapon.FallbackPaintKit = cosmetic.PaintKit;
             weapon.FallbackSeed = seed;
@@ -1725,7 +1760,7 @@ public sealed class SkinManager : IDisposable
                 return false;
             }
 
-            var statTrak = GetCustomization(player, KnifeTarget)?.StatTrak;
+            var statTrak = GetCustomization(player, KnifeTarget)?.StatTrak ?? (_enableAllWeaponsStatTrak ? 0 : null);
 
             TryChangeKnifeSubclass(weapon, knife.ItemDefinitionIndex);
             weapon.FallbackPaintKit = 0;

--- a/config.json
+++ b/config.json
@@ -24,6 +24,7 @@
     "Permission": "",
     "MaxNameTagLength": 20
   },
+  "EnableAllWeaponsStatTrak": true,
   "Definitions": {
     "Weapons": "data/weapons.json",
     "Knives": "data/knives.json",


### PR DESCRIPTION
## What

Adds a configuration switch for the default StatTrak behavior of AstraSkins weapon and knife skins.

## Configuration

- `EnableAllWeaponsStatTrak` defaults to `true`.
- When enabled, selected weapon and knife skins receive StatTrak starting at `0`, and kills continue to update the existing per-item counter.
- When disabled, the existing `!stattrak` command remains the only way to enable a per-item counter.
- Explicit per-player StatTrak counts continue to override the default.

No database schema changes are required. The existing `stattrak` selection rows are reused.

## Testing

- `dotnet build -c Release --no-restore`
- JSON validation
- `git diff --check`
