### PR TITLE
Handle stale profile loads across reconnects

### DIFF
--- a/AstraSkinsPlugin.cs
+++ b/AstraSkinsPlugin.cs
@@ -607,7 +607,7 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
 
         foreach (var player in Utilities.GetPlayers().Where(IsLiveHuman))
         {
-            _skinManager.ApplyAgentToPlayer(player, logFailures: false, loadIfMissing: false);
+            _skinManager.ApplyToPlayerWhenProfileReady(player, logFailures: false);
         }
 
         return HookResult.Continue;

--- a/SkinManager.cs
+++ b/SkinManager.cs
@@ -21,7 +21,9 @@ public sealed class SkinManager : IDisposable
     private readonly ILogger _logger;
     private readonly EconAttributeApplicator _econAttributes;
     private readonly Dictionary<ulong, PlayerSkinProfile> _profiles = new();
+    private readonly HashSet<ulong> _loadedProfiles = new();
     private readonly HashSet<ulong> _loadingProfiles = new();
+    private readonly HashSet<ulong> _applyAfterLoadRequests = new();
     private readonly HashSet<ulong> _activeSteamIds = new();
     private readonly Dictionary<ulong, ulong> _profileEpochs = new();
     private readonly object _storageQueueLock = new();
@@ -111,7 +113,9 @@ public sealed class SkinManager : IDisposable
     {
         _disposed = true;
         _activeSteamIds.Clear();
+        _loadedProfiles.Clear();
         _loadingProfiles.Clear();
+        _applyAfterLoadRequests.Clear();
         _profiles.Clear();
         _profileEpochs.Clear();
 
@@ -165,18 +169,34 @@ public sealed class SkinManager : IDisposable
         if (TryGetSteamId64(player, out var steamId))
         {
             _profiles.Remove(steamId);
-            _loadingProfiles.Remove(steamId);
+            _loadedProfiles.Remove(steamId);
+            _applyAfterLoadRequests.Remove(steamId);
             _activeSteamIds.Remove(steamId);
-            _profileEpochs.Remove(steamId);
+            if (_loadingProfiles.Contains(steamId))
+            {
+                BumpProfileEpoch(steamId);
+            }
+            else
+            {
+                _profileEpochs.Remove(steamId);
+            }
         }
     }
 
     public void Forget(ulong steamId64)
     {
         _profiles.Remove(steamId64);
-        _loadingProfiles.Remove(steamId64);
+        _loadedProfiles.Remove(steamId64);
+        _applyAfterLoadRequests.Remove(steamId64);
         _activeSteamIds.Remove(steamId64);
-        _profileEpochs.Remove(steamId64);
+        if (_loadingProfiles.Contains(steamId64))
+        {
+            BumpProfileEpoch(steamId64);
+        }
+        else
+        {
+            _profileEpochs.Remove(steamId64);
+        }
     }
 
     public void ApplyToPlayerWhenProfileReady(CCSPlayerController player, bool logFailures = false)
@@ -196,7 +216,7 @@ public sealed class SkinManager : IDisposable
             return;
         }
 
-        if (_profiles.ContainsKey(steamId))
+        if (_loadedProfiles.Contains(steamId))
         {
             ApplyToPlayer(player, logFailures);
             return;
@@ -329,6 +349,8 @@ public sealed class SkinManager : IDisposable
         BumpProfileEpoch(steamId);
         QueueStorageWrite($"profile reset for {steamId}", () => _storage.ResetProfile(steamId));
         _profiles.Remove(steamId);
+        _loadedProfiles.Remove(steamId);
+        _applyAfterLoadRequests.Remove(steamId);
         ClearPlayerCosmetics(player, logFailures: true);
     }
 
@@ -928,9 +950,29 @@ public sealed class SkinManager : IDisposable
             return;
         }
 
-        if (_profiles.ContainsKey(steamId64) || !_loadingProfiles.Add(steamId64))
+        if (_loadedProfiles.Contains(steamId64))
         {
             return;
+        }
+
+        if (_loadingProfiles.Contains(steamId64))
+        {
+            if (applyAfterLoad)
+            {
+                _applyAfterLoadRequests.Add(steamId64);
+            }
+
+            return;
+        }
+
+        if (!_loadingProfiles.Add(steamId64))
+        {
+            return;
+        }
+
+        if (applyAfterLoad)
+        {
+            _applyAfterLoadRequests.Add(steamId64);
         }
 
         var epoch = GetProfileEpoch(steamId64);
@@ -955,6 +997,23 @@ public sealed class SkinManager : IDisposable
                 }
 
                 _loadingProfiles.Remove(steamId64);
+                var applyAfterLoadRequested = _applyAfterLoadRequests.Remove(steamId64);
+
+                // The player disconnected or reset while this read was in
+                // flight. A reconnect may already be waiting on this load, so
+                // start a fresh read for the current lifecycle instead of
+                // accepting or reporting the stale result.
+                if (!_activeSteamIds.Contains(steamId64))
+                {
+                    _profileEpochs.Remove(steamId64);
+                    return;
+                }
+
+                if (GetProfileEpoch(steamId64) != epoch)
+                {
+                    LoadProfileInBackground(steamId64, applyAfterLoadRequested, logFailures);
+                    return;
+                }
 
                 if (failure is not null)
                 {
@@ -976,13 +1035,6 @@ public sealed class SkinManager : IDisposable
                     return;
                 }
 
-                // A changed epoch means the profile was reset while this load
-                // was in flight; its data is stale and must be discarded.
-                if (!_activeSteamIds.Contains(steamId64) || GetProfileEpoch(steamId64) != epoch)
-                {
-                    return;
-                }
-
                 if (_profiles.TryGetValue(steamId64, out var existing))
                 {
                     MergeLoadedProfile(existing, loaded);
@@ -992,7 +1044,9 @@ public sealed class SkinManager : IDisposable
                     _profiles[steamId64] = loaded;
                 }
 
-                if (!applyAfterLoad)
+                _loadedProfiles.Add(steamId64);
+
+                if (!applyAfterLoadRequested)
                 {
                     return;
                 }


### PR DESCRIPTION
## What

Prevent asynchronous profile reads from applying stale data after a player disconnects, reconnects, or resets their profile while a database load is in flight.

## Changes

- Track profile load completion separately from placeholder profiles created while a read is pending.
- Coalesce requests that need cosmetics applied after the current read completes.
- Invalidate in-flight reads on disconnect and reset with a per-player lifecycle epoch.
- Ignore stale callbacks and start a fresh read for the active lifecycle when needed.
- Route the existing round-freeze Agent application through `ApplyToPlayerWhenProfileReady` so it waits for the profile instead of applying an empty placeholder.

## Scope

This PR contains only the generic profile loading lifecycle changes. It does not include music-kit, configuration, language, or schema changes.

## Testing

- `dotnet build -c Release`
- `git diff --check`
