### PR TITLE
Integrate profile race, StatTrak, and bot takeover fixes

### DIFF
--- a/AstraSkinsPlugin.cs
+++ b/AstraSkinsPlugin.cs
@@ -69,6 +69,7 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         RegisterListener<Listeners.OnServerPrecacheResources>(OnServerPrecacheResources);
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawnPre, HookMode.Pre);
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawnPost, HookMode.Post);
+        RegisterEventHandler<EventBotTakeover>(OnBotTakeover, HookMode.Post);
         RegisterEventHandler<EventRoundFreezeEnd>(OnRoundFreezeEndPre, HookMode.Pre);
         RegisterEventHandler<EventPlayerDeath>(OnPlayerDeath);
         RegisterEventHandler<EventRoundMvp>(OnRoundMvp, HookMode.Pre);
@@ -116,18 +117,20 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         _config = config;
         _storage = storage;
         _skinManager = new SkinManager(storage, catalog, Logger,
-            (delay, action) => AddTimer(delay, () => action(), TimerFlags.STOP_ON_MAPCHANGE));
+            (delay, action) => AddTimer(delay, () => action(), TimerFlags.STOP_ON_MAPCHANGE),
+            config.EnableAllWeaponsStatTrak);
         _menuManager = new MenuManager(_skinManager, config, Localizer, Logger);
         _nextMusicKitHealthCheckUtc = DateTime.MinValue;
         _ready = true;
 
         Logger.LogInformation(
-            "Astra Skins loaded: {Weapons} weapons, {KnifeSkins} knife skins, {GloveSkins} glove skins, {Agents} agents, DB={DatabaseMode}, MusicKitMvpCounter={MusicKitMvpCounter}",
+            "Astra Skins loaded: {Weapons} weapons, {KnifeSkins} knife skins, {GloveSkins} glove skins, {Agents} agents, DB={DatabaseMode}, AllWeaponsStatTrak={AllWeaponsStatTrak}, MusicKitMvpCounter={MusicKitMvpCounter}",
             catalog.Weapons.Count,
             catalog.KnifeSkinsById.Count,
             catalog.GloveSkinsById.Count,
             catalog.Agents.Count,
             config.DatabaseMode,
+            config.EnableAllWeaponsStatTrak,
             config.EnableMusicKitMvpCounter);
     }
 
@@ -611,6 +614,28 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         return HookResult.Continue;
     }
 
+    private HookResult OnBotTakeover(EventBotTakeover @event, GameEventInfo info)
+    {
+        var player = @event.Userid;
+        if (!_ready || !IsLiveHuman(player))
+        {
+            return HookResult.Continue;
+        }
+
+        var playerSlot = player!.Slot;
+        var userId = player.UserId;
+        Server.NextFrame(() =>
+        {
+            var current = Utilities.GetPlayerFromSlot(playerSlot);
+            if (_ready && IsLiveHuman(current) && current!.UserId == userId)
+            {
+                _skinManager?.ApplyToPlayerWhenProfileReady(current);
+            }
+        });
+
+        return HookResult.Continue;
+    }
+
     private void ScheduleMusicKitReapply(float delay)
     {
         if (!_ready || _skinManager is null)
@@ -630,7 +655,7 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
 
         foreach (var player in Utilities.GetPlayers().Where(IsLiveHuman))
         {
-            _skinManager.ApplyAgentToPlayer(player, logFailures: false, loadIfMissing: false);
+            _skinManager.ApplyToPlayerWhenProfileReady(player, logFailures: false);
         }
 
         return HookResult.Continue;

--- a/Models/PluginConfig.cs
+++ b/Models/PluginConfig.cs
@@ -12,6 +12,7 @@ public sealed class PluginConfig : BasePluginConfig
     public MySqlConfig MySql { get; set; } = new();
     public MenuConfig Menu { get; set; } = new();
     public CustomizationConfig Customization { get; set; } = new();
+    public bool EnableAllWeaponsStatTrak { get; set; } = true;
     public bool EnableMusicKitMvpCounter { get; set; } = false;
     public DefinitionPathConfig Definitions { get; set; } = new();
     public bool EnableAdminReloadCommand { get; set; } = true;

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
 
 Overrides apply on top of the selected skin, take effect instantly, and persist in the database. They target the weapon currently held (knife included); pass `gloves` as the first argument to target equipped gloves instead. A skin must be selected for the item first.
 
-StatTrak works the same way: enable it on a weapon or knife and the counter goes up with every kill you get with that item, persisting across reconnects and map changes.
+StatTrak works the same way: enable it on a weapon or knife and the counter goes up with every kill you get with that item, persisting across reconnects and map changes. With `EnableAllWeaponsStatTrak` enabled (the default), every selected weapon or knife skin starts with StatTrak at `0`; set it to `false` to require `!stattrak` for each item.
 
 > **Tip:** seeds only change finishes whose pattern placement varies — Case Hardened, Crimson Web, Marble Fade, Fade. Most other skins look identical on every seed.
 
@@ -168,6 +168,7 @@ If `data/music_kits.json` is missing, the category simply stays hidden.
     "Permission": "",
     "MaxNameTagLength": 20
   },
+  "EnableAllWeaponsStatTrak": true,
   "EnableMusicKitMvpCounter": false,
   "Definitions": {
     "Weapons": "data/weapons.json",
@@ -195,6 +196,7 @@ If `data/music_kits.json` is missing, the category simply stays hidden.
 | `Customization.Enabled` | Master switch for `!seed` / `!wear` / `!nametag` |
 | `Customization.Permission` | Restrict customization to a flag; empty = everyone |
 | `Customization.MaxNameTagLength` | Name tag cap, 4–32 (default 20 matches the real game) |
+| `EnableAllWeaponsStatTrak` | Apply StatTrak at count 0 to every selected weapon/knife by default; set `false` to require `!stattrak` |
 | `EnableMusicKitMvpCounter` | Track per-player MVP counts for selected music kits |
 
 ### SQLite

--- a/SkinManager.cs
+++ b/SkinManager.cs
@@ -20,8 +20,11 @@ public sealed class SkinManager : IDisposable
     private readonly ISkinStorage _storage;
     private readonly ILogger _logger;
     private readonly EconAttributeApplicator _econAttributes;
+    private readonly bool _enableAllWeaponsStatTrak;
     private readonly Dictionary<ulong, PlayerSkinProfile> _profiles = new();
+    private readonly HashSet<ulong> _loadedProfiles = new();
     private readonly HashSet<ulong> _loadingProfiles = new();
+    private readonly HashSet<ulong> _applyAfterLoadRequests = new();
     private readonly HashSet<ulong> _activeSteamIds = new();
     private readonly Dictionary<ulong, ulong> _profileEpochs = new();
     private readonly object _storageQueueLock = new();
@@ -90,11 +93,17 @@ public sealed class SkinManager : IDisposable
 
     public DefinitionCatalog Catalog { get; private set; }
 
-    public SkinManager(ISkinStorage storage, DefinitionCatalog catalog, ILogger logger, Action<float, Action>? scheduleDelayed = null)
+    public SkinManager(
+        ISkinStorage storage,
+        DefinitionCatalog catalog,
+        ILogger logger,
+        Action<float, Action>? scheduleDelayed = null,
+        bool enableAllWeaponsStatTrak = true)
     {
         _storage = storage;
         Catalog = catalog;
         _logger = logger;
+        _enableAllWeaponsStatTrak = enableAllWeaponsStatTrak;
         _scheduleDelayed = scheduleDelayed;
         _econAttributes = new EconAttributeApplicator(logger);
     }
@@ -111,7 +120,9 @@ public sealed class SkinManager : IDisposable
     {
         _disposed = true;
         _activeSteamIds.Clear();
+        _loadedProfiles.Clear();
         _loadingProfiles.Clear();
+        _applyAfterLoadRequests.Clear();
         _profiles.Clear();
         _profileEpochs.Clear();
 
@@ -165,18 +176,34 @@ public sealed class SkinManager : IDisposable
         if (TryGetSteamId64(player, out var steamId))
         {
             _profiles.Remove(steamId);
-            _loadingProfiles.Remove(steamId);
+            _loadedProfiles.Remove(steamId);
+            _applyAfterLoadRequests.Remove(steamId);
             _activeSteamIds.Remove(steamId);
-            _profileEpochs.Remove(steamId);
+            if (_loadingProfiles.Contains(steamId))
+            {
+                BumpProfileEpoch(steamId);
+            }
+            else
+            {
+                _profileEpochs.Remove(steamId);
+            }
         }
     }
 
     public void Forget(ulong steamId64)
     {
         _profiles.Remove(steamId64);
-        _loadingProfiles.Remove(steamId64);
+        _loadedProfiles.Remove(steamId64);
+        _applyAfterLoadRequests.Remove(steamId64);
         _activeSteamIds.Remove(steamId64);
-        _profileEpochs.Remove(steamId64);
+        if (_loadingProfiles.Contains(steamId64))
+        {
+            BumpProfileEpoch(steamId64);
+        }
+        else
+        {
+            _profileEpochs.Remove(steamId64);
+        }
     }
 
     public void ApplyToPlayerWhenProfileReady(CCSPlayerController player, bool logFailures = false)
@@ -196,7 +223,7 @@ public sealed class SkinManager : IDisposable
             return;
         }
 
-        if (_profiles.ContainsKey(steamId))
+        if (_loadedProfiles.Contains(steamId))
         {
             ApplyToPlayer(player, logFailures);
             return;
@@ -539,6 +566,8 @@ public sealed class SkinManager : IDisposable
         BumpProfileEpoch(steamId);
         QueueStorageWrite($"profile reset for {steamId}", () => _storage.ResetProfile(steamId));
         _profiles.Remove(steamId);
+        _loadedProfiles.Remove(steamId);
+        _applyAfterLoadRequests.Remove(steamId);
         ClearPlayerCosmetics(player, logFailures: true);
         ApplyMusicKitState(player, 0, 0, logFailures: true);
     }
@@ -810,7 +839,35 @@ public sealed class SkinManager : IDisposable
         }
 
         var target = IsKnife(weaponName) ? KnifeTarget : weaponName;
-        if (!profile.Customizations.TryGetValue(target, out var customization) || customization.StatTrak is null)
+        var hasSelectedItem = IsKnife(weaponName)
+            ? profile.KnifeSkinId is not null || profile.KnifeId is not null
+            : profile.WeaponSkins.ContainsKey(weaponName);
+        if (!hasSelectedItem && !profile.Customizations.ContainsKey(target))
+        {
+            return;
+        }
+
+        if (!profile.Customizations.TryGetValue(target, out var customization))
+        {
+            if (!_enableAllWeaponsStatTrak)
+            {
+                return;
+            }
+
+            customization = new WeaponCustomization { StatTrak = 0 };
+            profile.Customizations[target] = customization;
+        }
+        else if (customization.StatTrak is null)
+        {
+            if (!_enableAllWeaponsStatTrak)
+            {
+                return;
+            }
+
+            customization.StatTrak = 0;
+        }
+
+        if (customization.StatTrak is null)
         {
             return;
         }
@@ -1154,9 +1211,29 @@ public sealed class SkinManager : IDisposable
             return;
         }
 
-        if (_profiles.ContainsKey(steamId64) || !_loadingProfiles.Add(steamId64))
+        if (_loadedProfiles.Contains(steamId64))
         {
             return;
+        }
+
+        if (_loadingProfiles.Contains(steamId64))
+        {
+            if (applyAfterLoad)
+            {
+                _applyAfterLoadRequests.Add(steamId64);
+            }
+
+            return;
+        }
+
+        if (!_loadingProfiles.Add(steamId64))
+        {
+            return;
+        }
+
+        if (applyAfterLoad)
+        {
+            _applyAfterLoadRequests.Add(steamId64);
         }
 
         var epoch = GetProfileEpoch(steamId64);
@@ -1181,6 +1258,23 @@ public sealed class SkinManager : IDisposable
                 }
 
                 _loadingProfiles.Remove(steamId64);
+                var applyAfterLoadRequested = _applyAfterLoadRequests.Remove(steamId64);
+
+                // The player disconnected or reset while this read was in
+                // flight. A reconnect may already be waiting on this load, so
+                // start a fresh read for the current lifecycle instead of
+                // accepting or reporting the stale result.
+                if (!_activeSteamIds.Contains(steamId64))
+                {
+                    _profileEpochs.Remove(steamId64);
+                    return;
+                }
+
+                if (GetProfileEpoch(steamId64) != epoch)
+                {
+                    LoadProfileInBackground(steamId64, applyAfterLoadRequested, logFailures);
+                    return;
+                }
 
                 if (failure is not null)
                 {
@@ -1202,13 +1296,6 @@ public sealed class SkinManager : IDisposable
                     return;
                 }
 
-                // A changed epoch means the profile was reset while this load
-                // was in flight; its data is stale and must be discarded.
-                if (!_activeSteamIds.Contains(steamId64) || GetProfileEpoch(steamId64) != epoch)
-                {
-                    return;
-                }
-
                 if (_profiles.TryGetValue(steamId64, out var existing))
                 {
                     MergeLoadedProfile(existing, loaded);
@@ -1218,7 +1305,9 @@ public sealed class SkinManager : IDisposable
                     _profiles[steamId64] = loaded;
                 }
 
-                if (!applyAfterLoad)
+                _loadedProfiles.Add(steamId64);
+
+                if (!applyAfterLoadRequested)
                 {
                     return;
                 }
@@ -1614,7 +1703,7 @@ public sealed class SkinManager : IDisposable
             var seed = customization?.Seed ?? cosmetic.Seed;
             var wear = customization?.Wear ?? cosmetic.Wear;
 
-            var statTrak = customization?.StatTrak;
+            var statTrak = customization?.StatTrak ?? (_enableAllWeaponsStatTrak ? 0 : null);
 
             weapon.FallbackPaintKit = cosmetic.PaintKit;
             weapon.FallbackSeed = seed;
@@ -1966,7 +2055,7 @@ public sealed class SkinManager : IDisposable
                 return false;
             }
 
-            var statTrak = GetCustomization(player, KnifeTarget)?.StatTrak;
+            var statTrak = GetCustomization(player, KnifeTarget)?.StatTrak ?? (_enableAllWeaponsStatTrak ? 0 : null);
 
             TryChangeKnifeSubclass(weapon, knife.ItemDefinitionIndex);
             weapon.FallbackPaintKit = 0;

--- a/config.json
+++ b/config.json
@@ -24,6 +24,7 @@
     "Permission": "",
     "MaxNameTagLength": 20
   },
+  "EnableAllWeaponsStatTrak": true,
   "EnableMusicKitMvpCounter": false,
   "Definitions": {
     "Weapons": "data/weapons.json",


### PR DESCRIPTION
## What changed
- Preserve loaded player profiles across reconnect and reset races.
- Add the global EnableAllWeaponsStatTrak configuration switch.
- Reapply the complete player profile after EventBotTakeover on the next frame.
- Keep the merged music-kit implementation and current v1.0.7 data/localization.

## Validation
- dotnet build -c Release: passed with 0 warnings and 0 errors.
- git diff --check: passed.
- Deployment package contents and ZIP integrity: verified.
- No database schema changes are included.