### PR TITLE
Make bot takeover cosmetics opt-in

### DIFF
--- a/AstraSkinsPlugin.cs
+++ b/AstraSkinsPlugin.cs
@@ -635,7 +635,7 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
     private HookResult OnBotTakeover(EventBotTakeover @event, GameEventInfo info)
     {
         var player = @event.Userid;
-        if (!_ready || !IsLiveHuman(player))
+        if (!_ready || _config?.ApplyPlayerCosmeticsOnBotTakeover != true || !IsLiveHuman(player))
         {
             return HookResult.Continue;
         }

--- a/Models/PluginConfig.cs
+++ b/Models/PluginConfig.cs
@@ -12,6 +12,9 @@ public sealed class PluginConfig : BasePluginConfig
     public MySqlConfig MySql { get; set; } = new();
     public MenuConfig Menu { get; set; } = new();
     public CustomizationConfig Customization { get; set; } = new();
+    // A possessed bot keeps the cosmetics applied to its pawn by other plugins.
+    // Opt in only when player cosmetics should replace that loadout on takeover.
+    public bool ApplyPlayerCosmeticsOnBotTakeover { get; set; } = false;
     public bool EnableMusicKitMvpCounter { get; set; } = false;
     public DefinitionPathConfig Definitions { get; set; } = new();
     public bool EnableAdminReloadCommand { get; set; } = true;

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ If `data/music_kits.json` is missing, the category simply stays hidden.
     "Permission": "",
     "MaxNameTagLength": 20
   },
+  "ApplyPlayerCosmeticsOnBotTakeover": false,
   "EnableMusicKitMvpCounter": false,
   "Definitions": {
     "Weapons": "data/weapons.json",
@@ -195,6 +196,7 @@ If `data/music_kits.json` is missing, the category simply stays hidden.
 | `Customization.Enabled` | Master switch for `!seed` / `!wear` / `!nametag` |
 | `Customization.Permission` | Restrict customization to a flag; empty = everyone |
 | `Customization.MaxNameTagLength` | Name tag cap, 4–32 (default 20 matches the real game) |
+| `ApplyPlayerCosmeticsOnBotTakeover` | Apply the human player's cosmetics to the possessed bot pawn; off by default to preserve bot loadouts |
 | `EnableMusicKitMvpCounter` | Track per-player MVP counts for selected music kits |
 
 ### SQLite

--- a/config.json
+++ b/config.json
@@ -24,6 +24,7 @@
     "Permission": "",
     "MaxNameTagLength": 20
   },
+  "ApplyPlayerCosmeticsOnBotTakeover": false,
   "EnableMusicKitMvpCounter": false,
   "Definitions": {
     "Weapons": "data/weapons.json",


### PR DESCRIPTION
## Problem

AstraSkins v1.0.8 reapplies the human player's profile to the pawn received after `EventBotTakeover`. When BotRandomizer has already applied cosmetics to that pawn, this overwrites the bot's weapon and knife state, including paint, wear, quality, and item definition. In practice this can make a possessed bot lose quality and replace its randomized knife with the player's saved knife type.

## Change

Add `ApplyPlayerCosmeticsOnBotTakeover`, defaulting to `false`. The existing reapply behavior remains available as an explicit opt-in, while the default preserves cosmetics applied by other plugins to the possessed bot pawn.

## Scope

- No database or schema changes.
- No changes to normal player spawn/apply behavior.
- No BotRandomizer changes.
- Configuration and README documentation included.

## Validation

- `dotnet build -c Release`: 0 warnings, 0 errors.
- `jq empty config.json` passed.
- `git diff --check` passed.

The conflict scenario is reproducible by static inspection: both plugins write the same possessed pawn and `CEconItemView`; no A/B timing assumption is required.
