### PR TITLE
Fix music kit cues across round transitions and C4 MVP deaths

### DIFF
--- a/AstraSkinsPlugin.cs
+++ b/AstraSkinsPlugin.cs
@@ -26,14 +26,23 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
     private MenuManager? _menuManager;
     private readonly Dictionary<int, ulong> _steamIdsBySlot = new();
     private readonly Dictionary<int, DateTime> _maintenanceCooldownsBySlot = new();
+    private readonly Dictionary<int, PendingMvpCue> _pendingMvpCuesBySlot = new();
     private DateTime _nextMusicKitHealthCheckUtc = DateTime.MinValue;
     private bool _ready;
     private bool _giveNamedItemHooked;
 
+    private readonly record struct PendingMvpCue(
+        int UserId,
+        ulong SteamId,
+        long MusicKitId,
+        long MusicKitMvps,
+        int Reason,
+        long Value);
+
     public PluginConfig Config { get; set; } = new();
 
     public override string ModuleName => "Astra Skins";
-    public override string ModuleVersion => "1.0.10";
+    public override string ModuleVersion => "1.0.10-mkfix8";
     public override string ModuleAuthor => "Ayrton09";
     public override string ModuleDescription => string.Empty;
 
@@ -70,11 +79,14 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawnPre, HookMode.Pre);
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawnPost, HookMode.Post);
         RegisterEventHandler<EventBotTakeover>(OnBotTakeover, HookMode.Post);
+        RegisterEventHandler<EventTeamIntroEnd>(OnTeamIntroEndPre, HookMode.Pre);
+        RegisterEventHandler<EventRoundStart>(OnRoundStartPre, HookMode.Pre);
         RegisterEventHandler<EventRoundFreezeEnd>(OnRoundFreezeEndPre, HookMode.Pre);
+        RegisterEventHandler<EventBombPlanted>(OnBombPlantedPre, HookMode.Pre);
         RegisterEventHandler<EventPlayerDeath>(OnPlayerDeath);
         RegisterEventHandler<EventRoundMvp>(OnRoundMvp, HookMode.Pre);
         RegisterEventHandler<EventPlayerDisconnect>(OnPlayerDisconnect);
-        RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
+        RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam, HookMode.Pre);
         HookGiveNamedItem();
 
         if (hotReload && _ready)
@@ -95,6 +107,7 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         _skinManager = null;
         _menuManager = null;
         _steamIdsBySlot.Clear();
+        _pendingMvpCuesBySlot.Clear();
         _ready = false;
     }
 
@@ -124,7 +137,8 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         _ready = true;
 
         Logger.LogInformation(
-            "Astra Skins loaded: {Weapons} weapons, {KnifeSkins} knife skins, {GloveSkins} glove skins, {Agents} agents, {MusicKits} music kits, DB={DatabaseMode}, AllWeaponsStatTrak={AllWeaponsStatTrak}, MusicKitMvpCounter={MusicKitMvpCounter}",
+            "Astra Skins loaded {Version}: {Weapons} weapons, {KnifeSkins} knife skins, {GloveSkins} glove skins, {Agents} agents, {MusicKits} music kits, DB={DatabaseMode}, AllWeaponsStatTrak={AllWeaponsStatTrak}, MusicKitMvpCounter={MusicKitMvpCounter}",
+            ModuleVersion,
             catalog.Weapons.Count,
             catalog.KnifeSkinsById.Count,
             catalog.GloveSkinsById.Count,
@@ -601,7 +615,9 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         if (_ready && player is { IsValid: true, IsBot: true })
         {
             // Bot spawns can make Valve reinitialize controller music for every
-            // player. Reapply after the new entity and inventory have settled.
+            // player. Write immediately for wait/action cues, then once more
+            // after the new entity and inventory have settled.
+            ApplyMusicKitToLivePlayers();
             ScheduleMusicKitReapply(0.25f);
         }
 
@@ -658,6 +674,19 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         return HookResult.Continue;
     }
 
+    private HookResult OnTeamIntroEndPre(EventTeamIntroEnd @event, GameEventInfo info)
+    {
+        ApplyMusicKitToLivePlayers();
+        return HookResult.Continue;
+    }
+
+    private HookResult OnRoundStartPre(EventRoundStart @event, GameEventInfo info)
+    {
+        _pendingMvpCuesBySlot.Clear();
+        ApplyMusicKitToLivePlayers();
+        return HookResult.Continue;
+    }
+
     private HookResult OnRoundFreezeEndPre(EventRoundFreezeEnd @event, GameEventInfo info)
     {
         if (!_ready || _skinManager is null)
@@ -672,6 +701,13 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
             _skinManager.ApplyAgentToPlayer(player, logFailures: false, loadIfMissing: true);
         }
 
+        ApplyMusicKitToLivePlayers();
+        return HookResult.Continue;
+    }
+
+    private HookResult OnBombPlantedPre(EventBombPlanted @event, GameEventInfo info)
+    {
+        ApplyMusicKitToLivePlayers();
         return HookResult.Continue;
     }
 
@@ -694,6 +730,43 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         if (player is not null && player.IsValid)
         {
             _menuManager?.Close(player);
+
+            if (string.Equals(@event.Weapon, "planted_c4", StringComparison.OrdinalIgnoreCase) &&
+                _pendingMvpCuesBySlot.TryGetValue(player.Slot, out var pendingMvp) &&
+                pendingMvp.UserId == player.UserId &&
+                pendingMvp.SteamId == player.SteamID)
+            {
+                var slot = player.Slot;
+                var userId = player.UserId;
+                AddTimer(0.1f, () =>
+                {
+                    var current = Utilities.GetPlayerFromSlot(slot);
+                    if (_ready && current is { IsValid: true } &&
+                        !current.IsBot && current.SteamID == pendingMvp.SteamId && current.UserId == userId)
+                    {
+                        ReplayMvpCueToClient(current, pendingMvp);
+                    }
+                }, TimerFlags.STOP_ON_MAPCHANGE);
+            }
+        }
+
+        // Keep the selected kit and MvpNoMusic=false so the death state does not
+        // leave the controller on a death track.
+        if (_ready && IsLiveHuman(player))
+        {
+            _skinManager?.TryApplySelectedMusicKit(player!, out _, logFailures: false);
+            var slot = player!.Slot;
+            var userId = player.UserId;
+            AddTimer(0.15f, () =>
+            {
+                var current = Utilities.GetPlayerFromSlot(slot);
+                if (_ready && IsLiveHuman(current) && current!.UserId == userId)
+                {
+                    // Death processing can overwrite the controller music state;
+                    // apply once after it settles so a C4-killed MVP keeps its anthem.
+                    _skinManager?.TryApplySelectedMusicKit(current, out _, logFailures: false);
+                }
+            }, TimerFlags.STOP_ON_MAPCHANGE);
         }
 
         var attacker = @event.Attacker;
@@ -714,7 +787,7 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         var player = @event.Userid;
         if (_ready && _skinManager is not null && player is { IsValid: true } && IsLiveHuman(player))
         {
-            var hasSelectedMusicKit = _skinManager.TryGetSelectedMusicKitId(player, out var musicKitId);
+            var hasSelectedMusicKit = _skinManager.TryApplySelectedMusicKit(player, out var musicKitId);
             if (hasSelectedMusicKit)
             {
                 // Keep the scoreboard MVP music consistent with the selected kit.
@@ -730,9 +803,83 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
             {
                 @event.Musickitmvps = _skinManager.RecordMusicKitMvp(player, musicKitId);
             }
+
+            if (hasSelectedMusicKit)
+            {
+                var slot = player.Slot;
+                var userId = player.UserId;
+                foreach (var delay in new[] { 0.05f, 0.2f })
+                {
+                    AddTimer(delay, () =>
+                    {
+                        var current = Utilities.GetPlayerFromSlot(slot);
+                        if (_ready && IsLiveHuman(current) && current!.UserId == userId)
+                        {
+                            // C4 death handling can overwrite the controller after
+                            // round_mvp; restore the selected kit after that write.
+                            _skinManager?.TryApplySelectedMusicKit(current, out _, logFailures: false);
+                        }
+                    }, TimerFlags.STOP_ON_MAPCHANGE);
+                }
+            }
+
+            if (@event.Nomusic == 0 && @event.Musickitid > 0)
+            {
+                _pendingMvpCuesBySlot[player.Slot] = new PendingMvpCue(
+                    player.UserId ?? -1,
+                    player.SteamID,
+                    @event.Musickitid,
+                    @event.Musickitmvps,
+                    @event.Reason,
+                    @event.Value);
+            }
+
         }
 
         return HookResult.Continue;
+    }
+
+    private void ReplayMvpCueToClient(CCSPlayerController player, PendingMvpCue pendingMvp)
+    {
+        EventRoundMvp? replay = null;
+        try
+        {
+            replay = new EventRoundMvp(force: true)
+            {
+                Userid = player,
+                Musickitid = pendingMvp.MusicKitId,
+                Musickitmvps = pendingMvp.MusicKitMvps,
+                Nomusic = 0,
+                Reason = pendingMvp.Reason,
+                Value = pendingMvp.Value
+            };
+
+            replay.FireEventToClient(player);
+            Logger.LogInformation(
+                "Astra Skins replayed round_mvp cue to C4-killed MVP: steam={SteamId}, slot={Slot}, kit={MusicKitId}, mvpCount={MusicKitMvps}",
+                player.SteamID,
+                player.Slot,
+                pendingMvp.MusicKitId,
+                pendingMvp.MusicKitMvps);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Astra Skins failed to replay round_mvp cue to C4-killed MVP {SteamId}.", player.SteamID);
+        }
+        finally
+        {
+            if (replay is not null)
+            {
+                try
+                {
+                    replay.Free();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(ex, "Astra Skins failed to free replayed round_mvp event.");
+                }
+            }
+        }
     }
 
     private HookResult OnPlayerDisconnect(EventPlayerDisconnect @event, GameEventInfo info)
@@ -742,6 +889,7 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         {
             _menuManager?.CloseSlot(player.Slot);
             _maintenanceCooldownsBySlot.Remove(player.Slot);
+            _pendingMvpCuesBySlot.Remove(player.Slot);
             _skinManager?.Forget(player);
             if (_steamIdsBySlot.Remove(player.Slot, out var steamId))
             {
@@ -762,6 +910,16 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
             {
                 _skinManager?.ApplyMusicKitWhenProfileReady(player, logFailures: false);
             }
+            else if (_ready && player.IsBot)
+            {
+                // bot_add of a dead bot may never spawn. Valve still resets
+                // human music kits when the bot joins a team. Reapply after
+                // the team change settles so wait/action cues see the kit.
+                ApplyMusicKitToLivePlayers();
+                ScheduleMusicKitReapply(0.01f);
+                ScheduleMusicKitReapply(0.15f);
+                ScheduleMusicKitReapply(0.5f);
+            }
         }
 
         return HookResult.Continue;
@@ -777,15 +935,16 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         if (steamId.SteamId64 != 0)
         {
             _steamIdsBySlot[playerSlot] = steamId.SteamId64;
+            // Auth often fires before the controller is a live human. Start the
+            // profile read so team-select music is not waiting on a first spawn.
+            _skinManager.PreloadProfile(steamId.SteamId64);
         }
 
         var player = Utilities.GetPlayerFromSlot(playerSlot);
         if (IsLiveHuman(player))
         {
             _skinManager.ApplyMusicKitWhenProfileReady(player!, logFailures: false);
-            return;
         }
-
     }
 
     private void OnMapStart(string mapName)

--- a/AstraSkinsPlugin.cs
+++ b/AstraSkinsPlugin.cs
@@ -117,19 +117,21 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         _config = config;
         _storage = storage;
         _skinManager = new SkinManager(storage, catalog, Logger,
-            (delay, action) => AddTimer(delay, () => action(), TimerFlags.STOP_ON_MAPCHANGE));
+            (delay, action) => AddTimer(delay, () => action(), TimerFlags.STOP_ON_MAPCHANGE),
+            config.EnableAllWeaponsStatTrak);
         _menuManager = new MenuManager(_skinManager, config, Localizer, Logger);
         _nextMusicKitHealthCheckUtc = DateTime.MinValue;
         _ready = true;
 
         Logger.LogInformation(
-            "Astra Skins loaded: {Weapons} weapons, {KnifeSkins} knife skins, {GloveSkins} glove skins, {Agents} agents, {MusicKits} music kits, DB={DatabaseMode}, MusicKitMvpCounter={MusicKitMvpCounter}",
+            "Astra Skins loaded: {Weapons} weapons, {KnifeSkins} knife skins, {GloveSkins} glove skins, {Agents} agents, {MusicKits} music kits, DB={DatabaseMode}, AllWeaponsStatTrak={AllWeaponsStatTrak}, MusicKitMvpCounter={MusicKitMvpCounter}",
             catalog.Weapons.Count,
             catalog.KnifeSkinsById.Count,
             catalog.GloveSkinsById.Count,
             catalog.Agents.Count,
             catalog.MusicKits.Count,
             config.DatabaseMode,
+            config.EnableAllWeaponsStatTrak,
             config.EnableMusicKitMvpCounter);
     }
 

--- a/Models/PlayerSkinProfile.cs
+++ b/Models/PlayerSkinProfile.cs
@@ -22,5 +22,11 @@ public sealed class WeaponCustomization
     public float? Wear { get; set; }
     public string? NameTag { get; set; }
     public int? StatTrak { get; set; }
-    public bool IsEmpty => Seed is null && Wear is null && NameTag is null && StatTrak is null;
+
+    // Only meaningful while EnableAllWeaponsStatTrak is on: it records that the
+    // player turned StatTrak off explicitly, which a null count cannot express
+    // once the global default would re-enable it.
+    public bool StatTrakDisabled { get; set; }
+
+    public bool IsEmpty => Seed is null && Wear is null && NameTag is null && StatTrak is null && !StatTrakDisabled;
 }

--- a/Models/PluginConfig.cs
+++ b/Models/PluginConfig.cs
@@ -15,6 +15,9 @@ public sealed class PluginConfig : BasePluginConfig
     // Off by default so a possessed bot keeps whatever cosmetics its pawn has
     // (for example from a bot randomizer plugin). Opt in to see your own instead.
     public bool ApplyPlayerCosmeticsOnBotTakeover { get; set; } = false;
+    // Off by default so upgrading an existing install does not change what
+    // players see; StatTrak stays opt-in through !stattrak unless enabled.
+    public bool EnableAllWeaponsStatTrak { get; set; } = false;
     public bool EnableMusicKitMvpCounter { get; set; } = false;
     public DefinitionPathConfig Definitions { get; set; } = new();
     public bool EnableAdminReloadCommand { get; set; } = true;

--- a/MySqlSkinStorage.cs
+++ b/MySqlSkinStorage.cs
@@ -261,10 +261,16 @@ public sealed class MySqlSkinStorage : ISkinStorage
         {
             GetOrAddCustomization(profile, target).NameTag = cosmeticId;
         }
-        else if (type.Equals("stattrak", StringComparison.OrdinalIgnoreCase) &&
-                 int.TryParse(cosmeticId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var statTrak))
+        else if (type.Equals("stattrak", StringComparison.OrdinalIgnoreCase))
         {
-            GetOrAddCustomization(profile, target).StatTrak = statTrak;
+            if (cosmeticId.Equals(SkinManager.StatTrakDisabledValue, StringComparison.OrdinalIgnoreCase))
+            {
+                GetOrAddCustomization(profile, target).StatTrakDisabled = true;
+            }
+            else if (int.TryParse(cosmeticId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var statTrak))
+            {
+                GetOrAddCustomization(profile, target).StatTrak = statTrak;
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ If `data/music_kits.json` is missing, the category simply stays hidden.
     "MaxNameTagLength": 20
   },
   "ApplyPlayerCosmeticsOnBotTakeover": false,
+  "EnableAllWeaponsStatTrak": false,
   "EnableMusicKitMvpCounter": false,
   "Definitions": {
     "Weapons": "data/weapons.json",
@@ -197,7 +198,8 @@ If `data/music_kits.json` is missing, the category simply stays hidden.
 | `Customization.Enabled` | Master switch for `!seed` / `!wear` / `!nametag` |
 | `Customization.Permission` | Restrict customization to a flag; empty = everyone |
 | `Customization.MaxNameTagLength` | Name tag cap, 4–32 (default 20 matches the real game) |
-| `ApplyPlayerCosmeticsOnBotTakeover` | Off by default: a bot you take over keeps its own loadout. Set to `true` to apply your knife, agent and music kit to the possessed bot (guns and gloves already in hand keep their look) |
+| `ApplyPlayerCosmeticsOnBotTakeover` | Apply the human player's cosmetics to the possessed bot pawn; off by default to preserve bot loadouts |
+| `EnableAllWeaponsStatTrak` | Start StatTrak at 0 for every weapon or knife with a selected skin |
 | `EnableMusicKitMvpCounter` | Track per-player MVP counts for selected music kits |
 
 ### SQLite

--- a/SkinManager.cs
+++ b/SkinManager.cs
@@ -267,7 +267,9 @@ public sealed class SkinManager : IDisposable
             return;
         }
 
-        if (!_profiles.TryGetValue(steamId, out var profile))
+        // A placeholder in _profiles is not a completed read. Treating its
+        // empty MusicKitId as "player chose none" skips retries until reconnect.
+        if (!_loadedProfiles.Contains(steamId) || !_profiles.TryGetValue(steamId, out var profile))
         {
             _activeSteamIds.Add(steamId);
             LoadProfileInBackground(steamId, applyAfterLoad: true, logFailures);
@@ -330,7 +332,7 @@ public sealed class SkinManager : IDisposable
 
     public void PreloadProfile(CCSPlayerController player)
     {
-        if (_disposed || !TryGetSteamId64(player, out var steamId) || _profiles.ContainsKey(steamId))
+        if (_disposed || !TryGetSteamId64(player, out var steamId) || _loadedProfiles.Contains(steamId))
         {
             return;
         }
@@ -341,7 +343,7 @@ public sealed class SkinManager : IDisposable
 
     public void PreloadProfile(ulong steamId64)
     {
-        if (_disposed || steamId64 == 0 || _profiles.ContainsKey(steamId64))
+        if (_disposed || steamId64 == 0 || _loadedProfiles.Contains(steamId64))
         {
             return;
         }
@@ -478,6 +480,34 @@ public sealed class SkinManager : IDisposable
     {
         try
         {
+            if (!TryGetSteamId64(player, out var steamId))
+            {
+                if (logFailures)
+                {
+                    _logger.LogWarning("Astra Skins cannot apply music kit: player SteamID64 is invalid.");
+                }
+
+                return;
+            }
+
+            if (!_loadedProfiles.Contains(steamId))
+            {
+                _activeSteamIds.Add(steamId);
+                LoadProfileInBackground(steamId, applyAfterLoad: true, logFailures);
+                // An in-memory selection (menu pick while the read is in flight)
+                // should still reach the controller. An empty placeholder must
+                // not write kit 0 and wipe a kit the engine still has.
+                if (!_profiles.TryGetValue(steamId, out var pending) ||
+                    string.IsNullOrWhiteSpace(pending.MusicKitId))
+                {
+                    return;
+                }
+
+                var (pendingKitId, pendingMvpCount) = ResolveMusicKitState(pending);
+                ApplyMusicKitState(player, pendingKitId, pendingMvpCount, logFailures);
+                return;
+            }
+
             var profile = GetProfile(player);
             var (kitId, mvpCount) = ResolveMusicKitState(profile);
             ApplyMusicKitState(player, kitId, mvpCount, logFailures);
@@ -489,6 +519,39 @@ public sealed class SkinManager : IDisposable
                 _logger.LogWarning(ex, "Astra Skins failed to resolve music kit for {SteamId}.", TryGetSteamId64(player, out var steamId) ? steamId : 0);
             }
         }
+    }
+
+    // Writes the selected kit onto the controller now, including MvpNoMusic=false.
+    // Used on death and round_mvp so a dead T MVP is not left on deathcam audio.
+    public bool TryApplySelectedMusicKit(CCSPlayerController player, out int musicKitId, bool logFailures = false)
+    {
+        musicKitId = 0;
+        if (_disposed || !TryGetSteamId64(player, out var steamId))
+        {
+            return false;
+        }
+
+        if (!_loadedProfiles.Contains(steamId))
+        {
+            _activeSteamIds.Add(steamId);
+            LoadProfileInBackground(steamId, applyAfterLoad: true, logFailures);
+            return false;
+        }
+
+        if (!_profiles.TryGetValue(steamId, out var profile))
+        {
+            return false;
+        }
+
+        var (kitId, mvpCount) = ResolveMusicKitState(profile);
+        if (kitId <= 0)
+        {
+            return false;
+        }
+
+        ApplyMusicKitState(player, kitId, mvpCount, logFailures);
+        musicKitId = kitId;
+        return true;
     }
 
     private (int KitId, int MvpCount) ResolveMusicKitState(PlayerSkinProfile profile)

--- a/SkinManager.cs
+++ b/SkinManager.cs
@@ -15,11 +15,17 @@ public sealed class SkinManager : IDisposable
     public const string KnifeTarget = "knife";
     public const string GloveTarget = "glove";
 
+    // Stored in the cosmetic_id column of a "stattrak" row to mark an explicit
+    // opt-out. It is not a number, so older builds ignore the row instead of
+    // misreading it as a count.
+    public const string StatTrakDisabledValue = "off";
+
     private const ulong MinimumCustomItemId = 65578;
 
     private readonly ISkinStorage _storage;
     private readonly ILogger _logger;
     private readonly EconAttributeApplicator _econAttributes;
+    private readonly bool _enableAllWeaponsStatTrak;
     private readonly Dictionary<ulong, PlayerSkinProfile> _profiles = new();
     // _profiles can hold a placeholder while a read is in flight, so loaded
     // completion is tracked separately; without this a failed read leaves the
@@ -95,12 +101,18 @@ public sealed class SkinManager : IDisposable
 
     public DefinitionCatalog Catalog { get; private set; }
 
-    public SkinManager(ISkinStorage storage, DefinitionCatalog catalog, ILogger logger, Action<float, Action>? scheduleDelayed = null)
+    public SkinManager(
+        ISkinStorage storage,
+        DefinitionCatalog catalog,
+        ILogger logger,
+        Action<float, Action>? scheduleDelayed = null,
+        bool enableAllWeaponsStatTrak = false)
     {
         _storage = storage;
         Catalog = catalog;
         _logger = logger;
         _scheduleDelayed = scheduleDelayed;
+        _enableAllWeaponsStatTrak = enableAllWeaponsStatTrak;
         _econAttributes = new EconAttributeApplicator(logger);
     }
 
@@ -825,18 +837,57 @@ public sealed class SkinManager : IDisposable
 
     public bool SetStatTrak(CCSPlayerController player, string target, int? count)
     {
+        // Turning StatTrak off has to be recorded, not just left empty: with the
+        // global default on, an absent row means "enabled at 0", so !stattrak
+        // reset would be undone the moment the item is applied again.
+        var storedValue = count?.ToString(CultureInfo.InvariantCulture)
+            ?? (_enableAllWeaponsStatTrak ? StatTrakDisabledValue : null);
+
         return SetCustomization(player, target, "stattrak",
-            count?.ToString(CultureInfo.InvariantCulture),
-            customization => customization.StatTrak = count,
+            storedValue,
+            customization =>
+            {
+                customization.StatTrak = count;
+                customization.StatTrakDisabled = count is null && _enableAllWeaponsStatTrak;
+            },
             requiresPaintKit: false);
     }
 
     public int? GetStatTrak(CCSPlayerController player, string target)
     {
-        return GetProfile(player).Customizations.TryGetValue(target, out var customization)
-            ? customization.StatTrak
-            : null;
+        var profile = GetProfile(player);
+        profile.Customizations.TryGetValue(target, out var customization);
+        return ResolveStatTrak(profile, target, customization);
     }
+
+    // The single place that turns stored state plus the global default into the
+    // count to apply. Explicit counts win, an explicit off wins over the
+    // default, and only then does the default hand out a fresh 0.
+    private int? ResolveStatTrak(PlayerSkinProfile profile, string target, WeaponCustomization? customization)
+    {
+        if (customization?.StatTrak is int explicitCount)
+        {
+            return explicitCount;
+        }
+
+        if (customization?.StatTrakDisabled == true || !_enableAllWeaponsStatTrak)
+        {
+            return null;
+        }
+
+        // The default only covers items the player actually picked a skin for,
+        // so stock weapons stay untouched.
+        return HasSelectedSkin(profile, target) ? 0 : null;
+    }
+
+    private static bool HasSelectedSkin(PlayerSkinProfile profile, string target) => target switch
+    {
+        KnifeTarget => profile.KnifeSkinId is not null || profile.KnifeId is not null,
+        // Gloves have no StatTrak in the game, so the default never covers
+        // them; an explicit count is still honoured if one is ever set.
+        GloveTarget => false,
+        _ => profile.WeaponSkins.ContainsKey(target)
+    };
 
     // Bumps the counter in place: no weapon refresh, since re-creating the
     // weapon on every kill would be disastrous.
@@ -859,13 +910,23 @@ public sealed class SkinManager : IDisposable
         }
 
         var target = IsKnife(weaponName) ? KnifeTarget : weaponName;
-        if (!profile.Customizations.TryGetValue(target, out var customization) || customization.StatTrak is null)
+        profile.Customizations.TryGetValue(target, out var customization);
+        if (ResolveStatTrak(profile, target, customization) is not int current)
         {
             return;
         }
 
-        var next = customization.StatTrak.Value + 1;
+        // With the global default on there may be no row yet: the first kill is
+        // what creates it, so a count only reaches storage once it is non-zero.
+        if (customization is null)
+        {
+            customization = new WeaponCustomization();
+            profile.Customizations[target] = customization;
+        }
+
+        var next = current + 1;
         customization.StatTrak = next;
+        customization.StatTrakDisabled = false;
         QueueStorageWrite($"stattrak {next} ({target}) for {steamId}",
             () => _storage.SaveCustomization(steamId, "stattrak", target, next.ToString(CultureInfo.InvariantCulture)));
 
@@ -1687,11 +1748,12 @@ public sealed class SkinManager : IDisposable
 
             // Resolving the entity name on a freshly created weapon is not
             // reliable, so prefer the target the caller already knows.
-            var customization = GetCustomization(player, isKnife ? KnifeTarget : customizationTarget ?? ResolveWeaponEntityName(weapon));
+            var resolvedTarget = isKnife ? KnifeTarget : customizationTarget ?? ResolveWeaponEntityName(weapon);
+            var customization = GetCustomization(player, resolvedTarget);
             var seed = customization?.Seed ?? cosmetic.Seed;
             var wear = customization?.Wear ?? cosmetic.Wear;
 
-            var statTrak = customization?.StatTrak;
+            var statTrak = ResolveStatTrak(GetProfile(player), resolvedTarget, customization);
 
             weapon.FallbackPaintKit = cosmetic.PaintKit;
             weapon.FallbackSeed = seed;
@@ -2043,7 +2105,7 @@ public sealed class SkinManager : IDisposable
                 return false;
             }
 
-            var statTrak = GetCustomization(player, KnifeTarget)?.StatTrak;
+            var statTrak = ResolveStatTrak(GetProfile(player), KnifeTarget, GetCustomization(player, KnifeTarget));
 
             TryChangeKnifeSubclass(weapon, knife.ItemDefinitionIndex);
             weapon.FallbackPaintKit = 0;

--- a/SqliteSkinStorage.cs
+++ b/SqliteSkinStorage.cs
@@ -241,10 +241,16 @@ public sealed class SqliteSkinStorage : ISkinStorage
         {
             GetOrAddCustomization(profile, target).NameTag = cosmeticId;
         }
-        else if (type.Equals("stattrak", StringComparison.OrdinalIgnoreCase) &&
-                 int.TryParse(cosmeticId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var statTrak))
+        else if (type.Equals("stattrak", StringComparison.OrdinalIgnoreCase))
         {
-            GetOrAddCustomization(profile, target).StatTrak = statTrak;
+            if (cosmeticId.Equals(SkinManager.StatTrakDisabledValue, StringComparison.OrdinalIgnoreCase))
+            {
+                GetOrAddCustomization(profile, target).StatTrakDisabled = true;
+            }
+            else if (int.TryParse(cosmeticId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var statTrak))
+            {
+                GetOrAddCustomization(profile, target).StatTrak = statTrak;
+            }
         }
     }
 

--- a/config.json
+++ b/config.json
@@ -25,6 +25,7 @@
     "MaxNameTagLength": 20
   },
   "ApplyPlayerCosmeticsOnBotTakeover": false,
+  "EnableAllWeaponsStatTrak": false,
   "EnableMusicKitMvpCounter": false,
   "Definitions": {
     "Weapons": "data/weapons.json",


### PR DESCRIPTION
Fixes two music kit timing issues in live rounds:

- Reapply selected music kits around team intro, round start, freeze end, bomb plant, and bot team changes so Valve's bot updates do not replace wait/action cues with the default kit.
- Preserve the selected MVP anthem when a player earns MVP and is then killed by the planted C4 shockwave by replaying the `round_mvp` cue to that client after the death event.
- Add the existing `EnableAllWeaponsStatTrak` configuration patch and keep its explicit opt-out behavior across SQLite and MySQL storage.

The implementation only marks controller music fields with `Utilities.SetStateChanged`; it does not dirty inventory services or `m_unMusicID`.

Validation: `dotnet build -c Release --no-restore` passes with 0 warnings and 0 errors.
