### PR TITLE
Reapply music kits when a bot joins mid-round

### DIFF
--- a/AstraSkinsPlugin.cs
+++ b/AstraSkinsPlugin.cs
@@ -90,6 +90,7 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         RegisterEventHandler<EventRoundMvp>(OnRoundMvp, HookMode.Pre);
         RegisterEventHandler<EventPlayerDisconnect>(OnPlayerDisconnect);
         RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
+        RegisterEventHandler<EventPlayerTeam>(OnBotTeamMusicReapply, HookMode.Pre);
         HookGiveNamedItem();
 
         if (hotReload && _ready)
@@ -698,8 +699,9 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
         var player = @event.Userid;
         if (_ready && player is { IsValid: true, IsBot: true })
         {
-            // Bot spawns can make Valve reinitialize controller music for every
-            // player. Reapply after the new entity and inventory have settled.
+            // Bot spawns can reset every human's kit. The victory cue can fire
+            // before the 1s reconcile, so write now and once after settle.
+            ApplyMusicKitToLivePlayers();
             ScheduleMusicKitReapply(0.25f);
         }
 
@@ -759,7 +761,11 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
     private HookResult OnRoundPrestart(EventRoundPrestart @event, GameEventInfo info)
     {
         _pendingMvpCue = null;
-        // Valve fills team_intro Xuid on this event; write after the assignment lands.
+        // Valve can reset kits again on the round boundary; wait cues sample
+        // before the 1s reconcile. Preview Xuid is filled on this event.
+        // MusicKitID is cleared on the next frame; write again there.
+        ApplyMusicKitToLivePlayers();
+        Server.NextFrame(ApplyMusicKitToLivePlayers);
         ScheduleTeamPreviewApply();
         return HookResult.Continue;
     }
@@ -988,6 +994,24 @@ public sealed class AstraSkinsPlugin : BasePlugin, IPluginConfig<PluginConfig>
             }
         }
 
+        return HookResult.Continue;
+    }
+
+    // bot_add of a dead bot may never spawn. Valve still resets human kits
+    // when the bot joins a team; victory/wait cues fire before the 1s reconcile.
+    private HookResult OnBotTeamMusicReapply(EventPlayerTeam @event, GameEventInfo info)
+    {
+        var player = @event.Userid;
+        if (!_ready || player is not { IsValid: true, IsBot: true })
+        {
+            return HookResult.Continue;
+        }
+
+        ApplyMusicKitToLivePlayers();
+        // Inventory MusicID is reset to 1 on the next frame after the bot
+        // joins a team; the Pre write still matches and is skipped.
+        Server.NextFrame(ApplyMusicKitToLivePlayers);
+        ScheduleMusicKitReapply(0.25f);
         return HookResult.Continue;
     }
 

--- a/SkinManager.cs
+++ b/SkinManager.cs
@@ -523,22 +523,39 @@ public sealed class SkinManager : IDisposable
         return (kitId, mvpCount);
     }
 
+    // The client plays wait/intro from m_pInventoryServices.m_unMusicID.
+    // Flag that pointer or the value stays server-side. Only dirty fields
+    // that actually changed so the 1s reconcile does not resend.
     private void ApplyMusicKitState(CCSPlayerController player, int kitId, int mvpCount, bool logFailures)
     {
         try
         {
             var inventory = player.InventoryServices;
-            if (inventory is not null)
+            var inventoryKitId = checked((ushort)Math.Clamp(kitId, 0, ushort.MaxValue));
+            if (inventory is not null && inventory.MusicID != inventoryKitId)
             {
-                inventory.MusicID = checked((ushort)Math.Clamp(kitId, 0, ushort.MaxValue));
+                inventory.MusicID = inventoryKitId;
+                Utilities.SetStateChanged(player, "CCSPlayerController", "m_pInventoryServices");
             }
 
-            player.MusicKitID = kitId;
-            Utilities.SetStateChanged(player, "CCSPlayerController", "m_iMusicKitID");
-            player.MusicKitMVPs = Math.Max(0, mvpCount);
-            Utilities.SetStateChanged(player, "CCSPlayerController", "m_iMusicKitMVPs");
-            player.MvpNoMusic = false;
-            Utilities.SetStateChanged(player, "CCSPlayerController", "m_bMvpNoMusic");
+            if (player.MusicKitID != kitId)
+            {
+                player.MusicKitID = kitId;
+                Utilities.SetStateChanged(player, "CCSPlayerController", "m_iMusicKitID");
+            }
+
+            var clampedMvpCount = Math.Max(0, mvpCount);
+            if (player.MusicKitMVPs != clampedMvpCount)
+            {
+                player.MusicKitMVPs = clampedMvpCount;
+                Utilities.SetStateChanged(player, "CCSPlayerController", "m_iMusicKitMVPs");
+            }
+
+            if (player.MvpNoMusic)
+            {
+                player.MvpNoMusic = false;
+                Utilities.SetStateChanged(player, "CCSPlayerController", "m_bMvpNoMusic");
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Stacked on #11. Review the last commit; the flag commit is that PR.

`bot_add` mid-round resets every human kit. Victory and the next wait cue sample before the 1s reconcile. A Pre write on `player_team` still matches (inventory `MusicID` is still the selected kit) and is skipped; Valve then writes `MusicID` to 1 on the **next frame**.

## What this PR does

- Reapply on bot team-join (`player_team` Pre) and on the following frame.
- Reapply on bot spawn, plus one 0.25s settle after the bot events.
- Reapply on `round_prestart` and on the following frame (`MusicKitID` is cleared there).

No extra round-event timer shotgun. No version string change. `ModuleVersion` stays `1.0.12`.

## Depends on

#11 (`m_pInventoryServices` dirty). Merge that first; this PR then only contains the bot-timing commit.

Validation: `dotnet build -c Release` — 0 warnings, 0 errors.